### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,22 @@
 language: go
 
 go:
-  - 1.11.x
+  - 1.12.x
 
 env:
-  - GO111MODULE=on 
-  
-script:
-  - go test -short -coverprofile=coverage.txt -covermode=count ./...
+  - GO111MODULE=on
 
-after_success:
-  - bash <(curl -s https://codecov.io/bash)  
+jobs:
+  include:
+    - name: "build"
+      script: go build ./...
+    - name: "lint"
+      install: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.1
+      script: golangci-lint run --deadline=7m
+    - name: "coverage"
+      script:
+      - go test -coverprofile=coverage.txt -covermode=atomic ./...
+      after_success: bash <(curl -s https://codecov.io/bash)
+    - name: "race"
+      script:
+      - go test -race ./... -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ jobs:
       script: golangci-lint run --deadline=7m
     - name: "coverage"
       script:
-      - go test -coverprofile=coverage.txt -covermode=atomic ./...
+      - go test -short -coverprofile=coverage.txt -covermode=atomic ./...
       after_success: bash <(curl -s https://codecov.io/bash)
     - name: "race"
       script:
-      - go test -race ./... -v
+      - go test -short -race ./... -v

--- a/float16_test.go
+++ b/float16_test.go
@@ -394,7 +394,10 @@ func TestAllFromFloat32(t *testing.T) {
 		}
 
 		// update hash with []byte of results
-		h.Write(buf.Bytes())
+		err = h.Write(buf.Bytes())
+		if err != nil {
+			panic(err)
+		}
 
 		buf.Reset()
 	}
@@ -432,7 +435,10 @@ func TestAllToFloat32(t *testing.T) {
 		}
 
 		// update hash with []byte of results
-		h.Write(buf.Bytes())
+		err = h.Write(buf.Bytes())
+		if err != nil {
+			panic(err)
+		}
 
 		buf.Reset()
 	}

--- a/float16_test.go
+++ b/float16_test.go
@@ -394,7 +394,7 @@ func TestAllFromFloat32(t *testing.T) {
 		}
 
 		// update hash with []byte of results
-		err = h.Write(buf.Bytes())
+		_, err = h.Write(buf.Bytes())
 		if err != nil {
 			panic(err)
 		}
@@ -435,7 +435,7 @@ func TestAllToFloat32(t *testing.T) {
 		}
 
 		// update hash with []byte of results
-		err = h.Write(buf.Bytes())
+		_, err = h.Write(buf.Bytes())
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Use jobs for build, lint, coverage, and race.  Use golangci-lint 1.23.1.  Bump Go from 1.11.x to 1.12.x.