### PR TITLE
Add cover.yml for code coverage without codecov.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
-# GitHub Actions - CI for Go with 3 jobs: lint, tests, and cover.
+# GitHub Actions - CI for Go with just linters and tests.  Use cover.yml for code coverage.
 # Author: Montgomery Edwards⁴⁴⁸ (github.com/x448)
-name: CI
+name: ci
 on: [push]
 jobs:
 
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-latest]
     steps:
     - name: Checkout code
       uses: actions/checkout@v1
@@ -43,21 +43,6 @@ jobs:
         go version
         go test -short -race -v ./...
 
-  # Check code coverage on latest-ubuntu with default version of Go.   Using codecov token.
-  cover:
-    name: Coverage
-    needs: [lint]
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v1
-      with:
-        fetch-depth: 2
-    - name: Generate coverprofile
-      run: |
-        go version
-        go test -short -coverprofile=coverage.txt -covermode=atomic ./...
-    - name: Codecov
-      uses: codecov/codecov-action@v1
-      with:
-        token: ${{secrets.CODECOV_TOKEN}}
+  ## Codecov.io is deprecated. IMHO, codecov.io asked for too much info.
+  ## Use https://github.com/x448/.github/workflows/cover.yml (go test -cover plus python = privacy).
+

--- a/.github/workflows/cover.yml
+++ b/.github/workflows/cover.yml
@@ -1,0 +1,23 @@
+# Go Cover - GitHub Actions Workflow
+# Author: Montgomery Edwards⁴⁴⁸ (github.com/x448)
+# This workflow checks if code coverage satisfies the required minimum.
+# The require minimum is specified in the workflow name. This keeps badge.svg and verified minimum in sync.
+# Example steps:
+# 1. Change workflow name from "cover 100%" to "cover ≥92.5%". Script will automatically use 92.5%.  
+# 2. Change README.md to use the new path to badge.svg because the path includes the workflow name.
+
+name: cover 100%
+on: [push]
+jobs:
+
+  # Verify minimum coverage is reached using `go test -short -cover` on latest-ubuntu with default version of Go.
+  cover:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+    - name: Go Coverage
+      run: go test -short -cover | python -c "import os,re,sys; min_cover = float(re.findall(r'\d*\.\d+|\d+', os.environ['GITHUB_WORKFLOW'])[0]); cover = float(re.findall(r'\d*\.\d+|\d+', sys.stdin.read())[0]); sys.exit(1) if (cover > 100) or (cover < min_cover) else sys.exit(0)"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Float16 (Binary16) in Go/Golang
-![](https://github.com/x448/float16/workflows/CI/badge.svg)
-[![codecov](https://codecov.io/gh/x448/float16/branch/master/graph/badge.svg?v=4)](https://codecov.io/gh/x448/float16)
+[![](https://github.com/x448/float16/workflows/ci/badge.svg)](https://github.com/x448/float16/blob/master/.github/workflows/ci.yml)
+[![](https://github.com/x448/float16/workflows/cover%20100%25/badge.svg)](https://github.com/x448/float16/blob/master/.github/workflows/cover.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/x448/float16)](https://goreportcard.com/report/github.com/x448/float16)
 [![Release](https://img.shields.io/github/release/x448/float16.svg?style=flat-square)](https://github.com/x448/float16/releases)
 [![License](http://img.shields.io/badge/license-mit-blue.svg?style=flat-square)](https://raw.githubusercontent.com/x448/float16/master/LICENSE)
@@ -11,7 +11,7 @@ IEEE 754 default rounding ("Round-to-Nearest RoundTiesToEven") is considered the
 
 All possible 4+ billion floating-point conversions with this library are verified to be correct.
 
-Lowercase "float16" refers to IEEE 754 binary16. And capitalized "Float16" refers to exported Go data type provided by this library.
+Lowercase "float16" refers to IEEE 754 binary16. And capitalized "Float16" refers to exported Go data type.
 
 ## Features
 Current features include:


### PR DESCRIPTION
Use GitHub Actions, `go test -short -cover`, and python to verify required coverage percent is satisfied.