### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,16 +3,17 @@ name: ci
 on: [push]
 jobs:
 
-  # Test on various OS with default Go version. Specifying Go version causes too much slowdown as of January 2020.
+  # Test on various OS and go versions.
   tests:
     name: Test on ${{matrix.os}}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        go-version: [1.16, 1.17, 1.18]
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Get dependencies
       run: go get -v -t -d ./...
     - name: Build project


### PR DESCRIPTION
Bump actions/checkout to v3.
Test Go 1.16, 1.17, and 1.18.
Add windows-latest.