### PR TITLE
Bump safer-golangci-lint.yml to 1.49.0

### DIFF
--- a/.github/workflows/safer-golangci-lint.yml
+++ b/.github/workflows/safer-golangci-lint.yml
@@ -8,7 +8,7 @@
 #
 # 100% of the script for downloading, installing, and running golangci-lint
 # is embedded in this file.  The embedded SHA384 digest is used to verify the 
-# downloaded golangci-lint tarball (golangci-lint-1.46.2-linux-amd64.tar.gz). 
+# downloaded golangci-lint tarball (golangci-lint-1.49.0-linux-amd64.tar.gz). 
 #
 # To use:
 #   Step 1. Copy this file into [github_repo]/.github/workflows/
@@ -20,15 +20,17 @@
 #   1. GOLINTERS_VERSION
 #   2. GOLINTERS_TGZ_DGST
 #
-# Release v1.46.2 (May 19, 2022)
-#   - actions/setup-go uses check-latest: true
-#   - Remove default permissions at top level and grant only read permission in the job.
-#   - Add workflow_dispatch.
-#   - Tidy some comments.
-#   - Bump golangci-lint to 1.46.2.
-#   - Checksum for golangci-lint-1.46.2-linux-amd64.tar.gz
-#     - SHA-256 is 242cd4f2d6ac0556e315192e8555784d13da5d1874e51304711570769c4f2b9b
-#     - SHA-384 is 60ade95e447f8c9a2dfc507c271c2ff41a0e0856f077bf2f734bcd80dd8268addf8cf1625c3e47a6516eb14f23423315
+# Release v1.49.0 (September 18, 2022)
+#   - Put Go version in environment variable GO_VERSION.
+#   - Increase timeout to 15m for big projects enabling more linters.
+#   - Use SHA-256 to verify (instead of SHA-384) and mention checksums file.
+#   - Bump Go to 1.19 (latest version of 1.19.x because check-latest: true).
+#   - Bump golangci-lint to 1.49.0
+#   - Hash of golangci-lint-1.49.0-linux-amd64.tar.gz
+#     - SHA-384: df59267a11317d2763fb6cb454a9b3a6a6d428f4750fcbb8604fb0d289b18a1b3b6cd2bfbf2a2fe976979e97a71fcc36
+#     - SHA-256: 5badc6e9fee2003621efa07e385910d9a88c89b38f6c35aded153193c5125178
+#                This SHA-256 matches golangci-lint-1.49.0-checksums.txt at
+#                https://github.com/golangci/golangci-lint/releases
 #
 name: linters
 
@@ -43,11 +45,12 @@ on:
     branches: [main, master]
 
 env:
-  GOLINTERS_VERSION: 1.46.2
+  GO_VERSION: 1.19
+  GOLINTERS_VERSION: 1.49.0
   GOLINTERS_ARCH: linux-amd64
-  GOLINTERS_TGZ_DGST: 60ade95e447f8c9a2dfc507c271c2ff41a0e0856f077bf2f734bcd80dd8268addf8cf1625c3e47a6516eb14f23423315
-  GOLINTERS_TIMEOUT: 5m
-  OPENSSL_DGST_CMD: openssl dgst -sha384 -r
+  GOLINTERS_TGZ_DGST: 5badc6e9fee2003621efa07e385910d9a88c89b38f6c35aded153193c5125178
+  GOLINTERS_TIMEOUT: 15m
+  OPENSSL_DGST_CMD: openssl dgst -sha256 -r
   CURL_CMD: curl --proto =https --tlsv1.2 --location --silent --show-error --fail
 
 jobs:
@@ -65,7 +68,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: ${{ env.GO_VERSION }}
           check-latest: true
 
       - name: Install golangci-lint

--- a/.github/workflows/safer-golangci-lint.yml
+++ b/.github/workflows/safer-golangci-lint.yml
@@ -8,7 +8,10 @@
 #
 # 100% of the script for downloading, installing, and running golangci-lint
 # is embedded in this file. The embedded SHA-256 digest is used to verify the
-# downloaded golangci-lint tarball (golangci-lint-1.49.0-linux-amd64.tar.gz). 
+# downloaded golangci-lint tarball (golangci-lint-1.49.0-linux-amd64.tar.gz).
+#
+# The embedded SHA-256 digest matches golangci-lint-1.49.0-checksums.txt at
+# https://github.com/golangci/golangci-lint/releases
 #
 # To use:
 #   Step 1. Copy this file into [github_repo]/.github/workflows/
@@ -29,7 +32,7 @@
 #   - Hash of golangci-lint-1.49.0-linux-amd64.tar.gz
 #     - SHA-384: df59267a11317d2763fb6cb454a9b3a6a6d428f4750fcbb8604fb0d289b18a1b3b6cd2bfbf2a2fe976979e97a71fcc36
 #     - SHA-256: 5badc6e9fee2003621efa07e385910d9a88c89b38f6c35aded153193c5125178
-#                This SHA-256 matches golangci-lint-1.49.0-checksums.txt at
+#                This SHA-256 digest matches golangci-lint-1.49.0-checksums.txt at
 #                https://github.com/golangci/golangci-lint/releases
 #
 name: linters

--- a/.github/workflows/safer-golangci-lint.yml
+++ b/.github/workflows/safer-golangci-lint.yml
@@ -7,7 +7,7 @@
 # safer-golangci-lint.yml
 #
 # 100% of the script for downloading, installing, and running golangci-lint
-# is embedded in this file.  The embedded SHA384 digest is used to verify the 
+# is embedded in this file. The embedded SHA-256 digest is used to verify the
 # downloaded golangci-lint tarball (golangci-lint-1.49.0-linux-amd64.tar.gz). 
 #
 # To use:


### PR DESCRIPTION
Changes:
- Put Go version in environment variable GO_VERSION.
- Increase timeout to 15m for big projects enabling more linters.
- Use SHA-256 to verify (instead of SHA-384) and mention checksums file.
- Bump Go to 1.19 (latest version of 1.19.x because check-latest: true).
- Bump golangci-lint to 1.49.0