### PR TITLE
Update ci.yml for go 1.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        go-version: [1.16, 1.17, 1.18]
+        go-version: [1.17, 1.18, 1.19]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read


### PR DESCRIPTION
Added go 1.19.  Removed go 1.16.