### PR TITLE
Bump safer-golangci-lint.yml to 1.52.2

### DIFF
--- a/.github/workflows/cover.yml
+++ b/.github/workflows/cover.yml
@@ -1,24 +1,30 @@
-# Copyright 2020-present Montgomery Edwards⁴⁴⁸ (github.com/x448).
-# This file is licensed under MIT License.
+# Copyright 2020-2023 Montgomery Edwards⁴⁴⁸ (github.com/x448).
+# This file is licensed under the MIT License. See LICENSE at https://github.com/x448/workflows for the full text.
 #
-# Go Cover - GitHub Actions Workflow
-# This GitHub Actions workflow checks if Go code coverage satisfies the required minimum.
-# The required minimum is specified in the workflow name. This keeps badge.svg and verified minimum in sync.
+# CI Go Cover 2023.5.14.
+# This GitHub Actions workflow checks if Go (Golang) code coverage satisfies the required minimum.
+# The required minimum is specified in the workflow name to keep badge.svg and verified minimum in sync.
 #
 # To help protect your privacy, this workflow avoids external services.
-# Using script visible here, this workflow simply runs `go test -short -cover` --> grep --> python.
+# This workflow simply runs `go test -short -cover` --> grep --> python.
+# The python script is embedded and readable in this file.
 # 
 # Steps to install and set minimum required coverage:
-# 0. Copy this file to github.com/OWNER_NAME/REPO_NAME/.github/workflows/cover.yml
+# 0. Copy this file to github.com/OWNER_NAME/REPO_NAME/.github/workflows/ci-go-cover.yml
 # 1. Change workflow name from "cover 100%" to "cover ≥92.5%". Script will automatically use 92.5%.  
-# 2. Change README.md to use the new path to badge.svg because the path includes the workflow name.
+# 2. Update README.md to use the new path to badge.svg because the path includes the workflow name.
 
-name: cover 100%
+name: cover ≥100%
 
-# Remove default permissions
+# Remove default permissions.
 permissions: {}
 
-on: [push]
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: [main, master]
+
 jobs:
 
   # Verify minimum coverage is reached using `go test -short -cover` on latest-ubuntu with default version of Go.
@@ -31,8 +37,13 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
+    - name: Install Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: 1.19
+        check-latest: true
     - name: Go Coverage
       run: |
         go version
-        go test -short -cover | grep "^.*coverage:.*of statements$" | python -c "import os,re,sys; cover_rpt = sys.stdin.read(); print(cover_rpt) if len(cover_rpt) != 0 else sys.exit(1); min_cover = float(re.findall(r'\d*\.\d+|\d+', os.environ['GITHUB_WORKFLOW'])[0]); cover = float(re.findall(r'\d*\.\d+|\d+', cover_rpt)[0]); sys.exit(1) if (cover > 100) or (cover < min_cover) else sys.exit(0)"
+        go test -short -cover | grep "^.*coverage:.*of statements$" | python -c "import os,re,sys; cover_rpt = sys.stdin.read(); print(cover_rpt) if len(cover_rpt) != 0 and len(cover_rpt.splitlines()) == 1 else sys.exit(1); min_cover = float(re.findall(r'\d*\.\d+|\d+', os.environ['GITHUB_WORKFLOW'])[0]); cover = float(re.findall(r'\d*\.\d+|\d+', cover_rpt)[0]); sys.exit(1) if (cover > 100) or (cover < min_cover) else sys.exit(0)"
       shell: bash

--- a/.github/workflows/safer-golangci-lint.yml
+++ b/.github/workflows/safer-golangci-lint.yml
@@ -48,7 +48,7 @@ on:
     branches: [main, master]
 
 env:
-  GO_VERSION: 1.20
+  GO_VERSION: '1.20'
   GOLINTERS_VERSION: 1.52.2
   GOLINTERS_ARCH: linux-amd64
   GOLINTERS_TGZ_DGST: c9cf72d12058a131746edd409ed94ccd578fbd178899d1ed41ceae3ce5f54501

--- a/.github/workflows/safer-golangci-lint.yml
+++ b/.github/workflows/safer-golangci-lint.yml
@@ -1,4 +1,4 @@
-# Copyright © 2021 Montgomery Edwards⁴⁴⁸ (github.com/x448).
+# Copyright © 2021-2023 Montgomery Edwards⁴⁴⁸ (github.com/x448).
 # This file is licensed under MIT License.
 #
 # Safer GitHub Actions Workflow for golangci-lint.
@@ -27,11 +27,13 @@
 #   1. GOLINTERS_VERSION
 #   2. GOLINTERS_TGZ_DGST
 #
-# Release v1.51.2 (February 19, 2023)
-#   - Bump golangci-lint to 1.51.2
-#   - Hash of golangci-lint-1.51.2-linux-amd64.tar.gz
-#     - SHA-256: 4de479eb9d9bc29da51aec1834e7c255b333723d38dbd56781c68e5dddc6a90b
-#                This SHA-256 digest matches golangci-lint-1.51.2-checksums.txt at
+# Release v1.52.2 (May 14, 2023)
+#   - Bump Go to 1.20
+#   - Bump actions/setup-go to v4
+#   - Bump golangci-lint to 1.52.2
+#   - Hash of golangci-lint-1.52.2-linux-amd64.tar.gz
+#     - SHA-256: c9cf72d12058a131746edd409ed94ccd578fbd178899d1ed41ceae3ce5f54501
+#                This SHA-256 digest matches golangci-lint-1.52.2-checksums.txt at
 #                https://github.com/golangci/golangci-lint/releases
 #
 name: linters
@@ -42,15 +44,14 @@ permissions: {}
 on:
   workflow_dispatch:
   pull_request:
-    types: [opened, synchronize, closed]
   push:
     branches: [main, master]
 
 env:
-  GO_VERSION: 1.19
-  GOLINTERS_VERSION: 1.51.2
+  GO_VERSION: 1.20
+  GOLINTERS_VERSION: 1.52.2
   GOLINTERS_ARCH: linux-amd64
-  GOLINTERS_TGZ_DGST: 4de479eb9d9bc29da51aec1834e7c255b333723d38dbd56781c68e5dddc6a90b
+  GOLINTERS_TGZ_DGST: c9cf72d12058a131746edd409ed94ccd578fbd178899d1ed41ceae3ce5f54501
   GOLINTERS_TIMEOUT: 15m
   OPENSSL_DGST_CMD: openssl dgst -sha256 -r
   CURL_CMD: curl --proto =https --tlsv1.2 --location --silent --show-error --fail
@@ -68,7 +69,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
           check-latest: true


### PR DESCRIPTION
Changes:
- Bump Go to 1.20.
- Bump actions/setup-go to v4.
- Bump golangci-lint to 1.52.2.
- Use defaults for pull_request.