### PR TITLE
Added SmallestNonZero constant

### DIFF
--- a/float16.go
+++ b/float16.go
@@ -40,10 +40,12 @@ const (
 	PrecisionOverflow
 )
 
-// SmallestNonzero value that is possible to represent in float16: 0.00006109476
+// SmallestNonzero is the smallest nonzero denormal value for float16 (0.000000059604645).
 // It's the float16 equivalent for [math.SmallestNonzeroFloat32] and [math.SmallestNonzeroFloat64].
-const SmallestNonzero = Float16(0b000010000000001)
-
+// For context, [math.SmallestNonzeroFloat32] used the formula 1 / 2**(127 - 1 + 23) to produce
+// the smallest denormal value for float32 (1.401298464324817070923729583289916131280e-45).
+// The equivalent formula for float16 is 1 / 2**(15 - 1 + 10). We use Float16(0x0001) to compile as const.
+const SmallestNonzero = Float16(0x0001)  // 5.9604645e-08 (effectively 0x1p-14 * 0x1p-10)
 // PrecisionFromfloat32 returns Precision without performing
 // the conversion.  Conversions from both Infinity and NaN
 // values will always report PrecisionExact even if NaN payload

--- a/float16.go
+++ b/float16.go
@@ -46,6 +46,7 @@ const (
 // the smallest denormal value for float32 (1.401298464324817070923729583289916131280e-45).
 // The equivalent formula for float16 is 1 / 2**(15 - 1 + 10). We use Float16(0x0001) to compile as const.
 const SmallestNonzero = Float16(0x0001)  // 5.9604645e-08 (effectively 0x1p-14 * 0x1p-10)
+
 // PrecisionFromfloat32 returns Precision without performing
 // the conversion.  Conversions from both Infinity and NaN
 // values will always report PrecisionExact even if NaN payload

--- a/float16.go
+++ b/float16.go
@@ -38,7 +38,12 @@ const (
 
 	// PrecisionOverflow is for Overflows. Cannot round-trip float32->float16->float32.
 	PrecisionOverflow
+
 )
+
+// SmallestNonzero value that is possible to represent in float16: 0.00006109476
+// It's the float16 equivalent for [math.SmallestNonzeroFloat32] and [math.SmallestNonzeroFloat64].
+const SmallestNonzero = Float16(0b000010000000001)
 
 // PrecisionFromfloat32 returns Precision without performing
 // the conversion.  Conversions from both Infinity and NaN

--- a/float16.go
+++ b/float16.go
@@ -38,7 +38,6 @@ const (
 
 	// PrecisionOverflow is for Overflows. Cannot round-trip float32->float16->float32.
 	PrecisionOverflow
-
 )
 
 // SmallestNonzero value that is possible to represent in float16: 0.00006109476

--- a/float16.go
+++ b/float16.go
@@ -45,7 +45,7 @@ const (
 // For context, [math.SmallestNonzeroFloat32] used the formula 1 / 2**(127 - 1 + 23) to produce
 // the smallest denormal value for float32 (1.401298464324817070923729583289916131280e-45).
 // The equivalent formula for float16 is 1 / 2**(15 - 1 + 10). We use Float16(0x0001) to compile as const.
-const SmallestNonzero = Float16(0x0001)  // 5.9604645e-08 (effectively 0x1p-14 * 0x1p-10)
+const SmallestNonzero = Float16(0x0001) // 5.9604645e-08 (effectively 0x1p-14 * 0x1p-10)
 
 // PrecisionFromfloat32 returns Precision without performing
 // the conversion.  Conversions from both Infinity and NaN

--- a/float16_test.go
+++ b/float16_test.go
@@ -797,7 +797,7 @@ func checkRoundTrippedPrecision(t *testing.T, u32 uint32, u16 uint16, u32bis uin
 }
 
 func TestSmallestNonzero(t *testing.T) {
-	want := float32(0x1p-24)  // -15 + 1 - 10
+	want := float32(0x1p-24) // -15 + 1 - 10
 	if float16.SmallestNonzero.Float32() != want {
 		t.Errorf("Invalid SmallestNonzero to float32 conversion: Float16=%s, wanted %g", float16.SmallestNonzero, want)
 	}

--- a/float16_test.go
+++ b/float16_test.go
@@ -797,7 +797,7 @@ func checkRoundTrippedPrecision(t *testing.T, u32 uint32, u16 uint16, u32bis uin
 }
 
 func TestSmallestNonzero(t *testing.T) {
-	want := float32(0x1p-24)
+	want := float32(0x1p-24)  // -15 + 1 - 10
 	if float16.SmallestNonzero.Float32() != want {
 		t.Errorf("Invalid SmallestNonzero to float32 conversion: Float16=%s, wanted %g", float16.SmallestNonzero, want)
 	}

--- a/float16_test.go
+++ b/float16_test.go
@@ -794,5 +794,11 @@ func checkRoundTrippedPrecision(t *testing.T, u32 uint32, u16 uint16, u32bis uin
 			t.Errorf("PrecisionFromfloat32 in f32bits=0x%08x (%032b) (%f), out f16bits=0x%04x (%v), back=0x%08x (%f), got %v, wanted PrecisionExact, exp=%d, coef=%d, drpd=%d", u32, u32, f32, u16, f16, u32bis, f32bis, pre, exp32, coef32, dropped32)
 		}
 	}
+}
 
+func TestSmallestNonzero(t *testing.T) {
+	want := float32(0x1p-24)
+	if float16.SmallestNonzero.Float32() != want {
+		t.Errorf("Invalid SmallestNonzero to float32 conversion: Float16=%s, wanted %g", float16.SmallestNonzero, want)
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/x448/float16
 
-go 1.11
+go 1.13


### PR DESCRIPTION
* Added the SmallestNonZero constant (0.00006109476).
* Changed `go.mod` to depend on go > 1.13, when support for binary constants was added. It is still very old (we are in go1.22 already).



