### PR TITLE
Remove 3 abandoned linters obsoleted by unused linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,6 @@
 linters:
   disable-all: true
   enable:
-    - deadcode
     - dupl    
     - errcheck
     - goconst
@@ -16,12 +15,10 @@ linters:
     - nilerr
     - revive
     - staticcheck
-    - structcheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
    
 issues:
   # Excluding configuration per-path, per-linter, per-text and per-source


### PR DESCRIPTION
Removed deadcode, structcheck, and varcheck.

Noise removed in ci logs:

```
level=warning msg="[runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused."
level=warning msg="[runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused."
level=warning msg="[runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused."
```