### PR TITLE
.github: bump go versions in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,20 +21,20 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        go-version: [1.17, 1.18, 1.19]
+        go-version: [1.17, 1.22, 1.23]  # oldest supported version and latest 2 versions
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
 
     steps:
     - name: Install Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
       with:
         go-version: ${{ matrix.go-version }}
         check-latest: true
 
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
     - name: Get dependencies
       run: go get -v -t -d ./...


### PR DESCRIPTION
Update ci.yml to:
- Use go1.17, go1.22, and go1.23
- Pin dependencies