### PR TITLE
.github: bump go and pin versions in cover.yml

### DIFF
--- a/.github/workflows/cover.yml
+++ b/.github/workflows/cover.yml
@@ -1,7 +1,7 @@
 # Copyright 2020-2023 Montgomery Edwards⁴⁴⁸ (github.com/x448).
 # This file is licensed under the MIT License. See LICENSE at https://github.com/x448/workflows for the full text.
 #
-# CI Go Cover 2023.5.14.
+# CI Go Cover 2024.9.21.
 # This GitHub Actions workflow checks if Go (Golang) code coverage satisfies the required minimum.
 # The required minimum is specified in the workflow name to keep badge.svg and verified minimum in sync.
 #
@@ -36,11 +36,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: Install Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
       with:
-        go-version: 1.19
+        go-version: 1.23
         check-latest: true
     - name: Go Coverage
       run: |


### PR DESCRIPTION
Bump to go1.23 and pin versions.