### PR TITLE
Add codeql group to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      
+    groups:
+      codeql:
+        patterns:
+          - "github/codeql-action*"
+
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:


### PR DESCRIPTION
Copied from [fxamacker/cbor](https://github.com/fxamacker/cbor) to fix dependabot errors when more than one action in codeql workflow needs version bump.